### PR TITLE
Evaluation order in this case is unspecified

### DIFF
--- a/src/trie.h
+++ b/src/trie.h
@@ -77,7 +77,8 @@ class Trie {
 			typename key_list::const_iterator end
 		) {
 			if ( current != end ) {
-				return this->children_[*current].add(++current, end);
+				auto element = *current;
+				return this->children_[element].add(++current, end);
 			} else {
 				return this;
 			}


### PR DESCRIPTION
On Visual C++ 2010, the `++current` was being evaluated before `[*current]`, causing a deref of `end` and a crash.
